### PR TITLE
Corrected makefile and packaging to support netcoreapp/new dotnet tools

### DIFF
--- a/OctopusProjectBuilder.Console.nuspec
+++ b/OctopusProjectBuilder.Console.nuspec
@@ -20,8 +20,9 @@
     <language>en-US</language>
   </metadata>
   <files>
-    <file src="OctopusProjectBuilder.Console\bin\Release\*.dll" target="" />
-    <file src="OctopusProjectBuilder.Console\bin\Release\*.exe" target="" />
+    <file src="OctopusProjectBuilder.Console\bin\Release\netcoreapp2.0\publish\*.dll" target="tools" />
+    <file src="OctopusProjectBuilder.Console\bin\Release\netcoreapp2.0\publish\*.bat" target="tools" />
+    <file src="OctopusProjectBuilder.Console\bin\Release\netcoreapp2.0\publish\*.json" target="tools" />
     <file src="LICENSE" target="\LICENSE" />
     <file src="LICENSE-YamlDotNet" target="\LICENSE-YamlDotNet" />
     <file src="Manual.md" target="" />

--- a/OctopusProjectBuilder.Console/OctopusProjectBuilder.Console.bat
+++ b/OctopusProjectBuilder.Console/OctopusProjectBuilder.Console.bat
@@ -1,0 +1,1 @@
+dotnet OctopusProjectBuilder.Console.dll

--- a/OctopusProjectBuilder.Console/OctopusProjectBuilder.Console.csproj
+++ b/OctopusProjectBuilder.Console/OctopusProjectBuilder.Console.csproj
@@ -1,9 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="OctopusProjectBuilder.Console.bat" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="OctopusProjectBuilder.Console.bat" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Common.Logging" Version="3.4.1" />
@@ -19,9 +27,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="log4net.config">
+    <Content Update="OctopusProjectBuilder.Console.bat">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    </Content>
   </ItemGroup>
 
 </Project>

--- a/OctopusProjectBuilder.Uploader.Tests/OctopusProjectBuilder.Uploader.Tests.csproj
+++ b/OctopusProjectBuilder.Uploader.Tests/OctopusProjectBuilder.Uploader.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="autofixture" Version="4.3.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="nunit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="Octopus.Client" Version="3.15.1" />

--- a/OctopusProjectBuilder.YamlReader.Tests/OctopusProjectBuilder.YamlReader.Tests.csproj
+++ b/OctopusProjectBuilder.YamlReader.Tests/OctopusProjectBuilder.YamlReader.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="autofixture" Version="4.3.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="nunit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="YamlDotNet" Version="4.3.1" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,17 +1,10 @@
 version: '{build}'
-
 skip_tags: false
-image: Visual Studio 2015
-platform: Any CPU
-configuration: Release
-
-cache:
-  - packages -> **\packages.config  # preserve "packages" directory in the root of build folder but will reset it if packages.config is modified
+image: Visual Studio 2017
+test: off
 
 build_script:
   - ps: make\make.ps1 -t build -ap Version:$($env:APPVEYOR_REPO_TAG_NAME)
-
-test: off
 
 artifacts:
   - path: reports

--- a/make/Makefile.ps1
+++ b/make/Makefile.ps1
@@ -12,7 +12,7 @@ Define-Step -Name 'Tests' -Target 'build' -Body {
 
 	$dotCover = Fetch-Package JetBrains.dotCover.CommandLineTools 2018.1.4
 	$reportGenerator = Fetch-Package "ReportGenerator" 3.1.2
-	$dotnet = & where.exe dotnet.exe
+	$dotnet = get-command dotnet.exe | Select-Object -ExpandProperty Definition
 
 	$reportDirectory="reports"
 	function Run-TestsWithCoverage($csprojFileInfo)

--- a/make/Makefile.ps1
+++ b/make/Makefile.ps1
@@ -19,7 +19,7 @@ Define-Step -Name 'Tests' -Target 'build' -Body {
 	{
 		Write-ShortStatus "Testing $($csprojFileInfo.Name)..."
 		$output = "$reportDirectory\$($csprojFileInfo.Name).dcvr"
-		call $dotCover\tools\dotCover.exe cover "/TargetExecutable=$dotnet" /TargetArguments="test $($csprojFileInfo.FullName) --configuration Release --no-build --no-restore" /Output=$output /Filters="+:module=OctopusProjectBuilder*;-:module=*Tests*"
+		call $dotCover\tools\dotCover.exe cover /TargetExecutable="""$dotnet""" /TargetArguments="test $($csprojFileInfo.FullName) --configuration Release --no-build --no-restore" /Output=$output /Filters="+:module=OctopusProjectBuilder*;-:module=*Tests*"
 		return $output
 	}
 

--- a/make/Makefile.ps1
+++ b/make/Makefile.ps1
@@ -4,6 +4,7 @@ Define-Step -Name 'Update Assembly Info' -Target 'build' -Body {
 }
 
 Define-Step -Name 'Build' -Target 'build' -Body {
+	call dotnet --version
 	call dotnet build OctopusProjectBuilder.sln --configuration Release
 }
 

--- a/make/Makefile.ps1
+++ b/make/Makefile.ps1
@@ -4,7 +4,6 @@ Define-Step -Name 'Update Assembly Info' -Target 'build' -Body {
 }
 
 Define-Step -Name 'Build' -Target 'build' -Body {
-	call dotnet --version
 	call dotnet build OctopusProjectBuilder.sln --configuration Release
 }
 
@@ -20,7 +19,7 @@ Define-Step -Name 'Tests' -Target 'build' -Body {
 	{
 		Write-ShortStatus "Testing $($csprojFileInfo.Name)..."
 		$output = "$reportDirectory\$($csprojFileInfo.Name).dcvr"
-		call $dotCover\tools\dotCover.exe cover /TargetExecutable="""$dotnet""" /TargetArguments="test $($csprojFileInfo.FullName) --configuration Release --no-build --no-restore" /Output=$output /Filters="+:module=OctopusProjectBuilder*;-:module=*Tests*"
+		call $dotCover\tools\dotCover.exe cover /TargetExecutable=$dotnet /TargetArguments="test $($csprojFileInfo.FullName) --configuration Release" /Output=$output /Filters="+:module=OctopusProjectBuilder*;-:module=*Tests*"
 		return $output
 	}
 

--- a/make/Makefile.ps1
+++ b/make/Makefile.ps1
@@ -4,30 +4,66 @@ Define-Step -Name 'Update Assembly Info' -Target 'build' -Body {
 }
 
 Define-Step -Name 'Build' -Target 'build' -Body {
-	call $Context.NugetExe restore OctopusProjectBuilder.sln
-	call "${env:ProgramFiles(x86)}\MSBuild\14.0\Bin\msbuild.exe" OctopusProjectBuilder.sln /t:"Clean,Build" /p:Configuration=Release /m /verbosity:m /nologo /p:TreatWarningsAsErrors=true
+	call dotnet build OctopusProjectBuilder.sln --configuration Release
 }
 
 Define-Step -Name 'Tests' -Target 'build' -Body {
 	. (require 'psmake.mod.testing')
 
-	$tests = @()
-	$tests += Define-NUnit3Tests -GroupName 'Unit Tests' -TestAssembly "*.Tests\bin\Release\*.Tests.dll"
+	$dotCover = Fetch-Package JetBrains.dotCover.CommandLineTools 2018.1.4
+	$reportGenerator = Fetch-Package "ReportGenerator" 3.1.2
+	$dotnet = & where.exe dotnet.exe
 
-	$tests `
-        | Run-Tests -EraseReportDirectory -Cover -CodeFilter '+[OctopusProjectBuilder*]* -[*.Tests*]*' -TestFilter '*.Tests.dll' `
-        | Generate-CoverageSummary `
-        | Check-AcceptableCoverage -AcceptableCoverage 89
+	$reportDirectory="reports"
+	function Run-TestsWithCoverage($csprojFileInfo)
+	{
+		Write-ShortStatus "Testing $($csprojFileInfo.Name)..."
+		$output = "$reportDirectory\$($csprojFileInfo.Name).dcvr"
+		call $dotCover\tools\dotCover.exe cover /TargetExecutable=$dotnet /TargetArguments="test $($csprojFileInfo.FullName) --configuration Release --no-build --no-restore" /Output=$output /Filters="+:module=OctopusProjectBuilder*;-:module=*Tests*"
+		return $output
+	}
+
+	function Merge-Reports
+	{
+		param(
+		[Parameter(Mandatory=$true,ValueFromPipeline=$true)]
+		$DcvrFiles
+		)
+		begin { $results=@() }
+		process { $results += $_ }
+		end {
+			$output = "$reportDirectory\unit-tests.dcvr"
+			$source = $results -join ';'
+			call $dotCover\tools\dotCover.exe merge /Source=$source /Output=$output
+			return $output;
+		}
+	}
+
+	function Convert-Report($dcvrFile)
+	{
+		$output="$reportDirectory\unit-tests-coverage.xml"
+		call $dotCover\tools\dotCover.exe report /Source=$dcvrFile /ReportType=DetailedXML /Output=$output
+		return Create-Object @{ ReportDirectory=$reportDirectory; CoverageReports=$output; }
+	}
+
+	Remove-Item $reportDirectory -Force -Recurse -ErrorAction SilentlyContinue
+
+	Get-ChildItem -Recurse . -Filter *.Tests.csproj `
+		| %{ Run-TestsWithCoverage $_ } `
+		| Merge-Reports `
+		| %{ Convert-Report $_} `
+		| Generate-CoverageSummary -ReportGeneratorVersion 3.1.2 `
+		| Check-AcceptableCoverage -AcceptableCoverage 89
 }
 
 Define-Step -Name 'Documentation generation' -Target 'build' -Body {
-	& OctopusProjectBuilder.DocGen\bin\Release\OctopusProjectBuilder.DocGen.exe | out-file Manual.md -Encoding utf8
+	& dotnet run --project OctopusProjectBuilder.DocGen\OctopusProjectBuilder.DocGen.csproj --configuration Release | out-file Manual.md -Encoding utf8
 	if ($LastExitCode -ne 0) { throw "A program execution was not successful (Exit code: $LASTEXITCODE)." }
 }
 
 Define-Step -Name 'Packaging' -Target 'build' -Body {
 	. (require 'psmake.mod.packaging')
-	
+	call dotnet publish OctopusProjectBuilder.Console\OctopusProjectBuilder.Console.csproj --configuration Release --no-build
 	Package-DeployableNuSpec -Package 'OctopusProjectBuilder.Console.nuspec' -version $VERSION
 }
 

--- a/make/Makefile.ps1
+++ b/make/Makefile.ps1
@@ -19,7 +19,7 @@ Define-Step -Name 'Tests' -Target 'build' -Body {
 	{
 		Write-ShortStatus "Testing $($csprojFileInfo.Name)..."
 		$output = "$reportDirectory\$($csprojFileInfo.Name).dcvr"
-		call $dotCover\tools\dotCover.exe cover /TargetExecutable=$dotnet /TargetArguments="test $($csprojFileInfo.FullName) --configuration Release --no-build --no-restore" /Output=$output /Filters="+:module=OctopusProjectBuilder*;-:module=*Tests*"
+		call $dotCover\tools\dotCover.exe cover "/TargetExecutable=$dotnet" /TargetArguments="test $($csprojFileInfo.FullName) --configuration Release --no-build --no-restore" /Output=$output /Filters="+:module=OctopusProjectBuilder*;-:module=*Tests*"
 		return $output
 	}
 

--- a/make/Makefile.ps1
+++ b/make/Makefile.ps1
@@ -19,7 +19,7 @@ Define-Step -Name 'Tests' -Target 'build' -Body {
 	{
 		Write-ShortStatus "Testing $($csprojFileInfo.Name)..."
 		$output = "$reportDirectory\$($csprojFileInfo.Name).dcvr"
-		call $dotCover\tools\dotCover.exe cover /TargetExecutable=$dotnet /TargetArguments="test $($csprojFileInfo.FullName) --configuration Release" /Output=$output /Filters="+:module=OctopusProjectBuilder*;-:module=*Tests*"
+		call $dotCover\tools\dotCover.exe cover /TargetExecutable=$dotnet /TargetArguments="test $($csprojFileInfo.FullName) --configuration Release --no-build --no-restore" /Output=$output /Filters="+:module=OctopusProjectBuilder*;-:module=*Tests*"
 		return $output
 	}
 

--- a/make/Modules.ps1
+++ b/make/Modules.ps1
@@ -1,5 +1,5 @@
 Write-Output @{
 	'psmake.mod.packaging' = '1.1.0.0';
 	'psmake.mod.update-version-info' = '1.2.0.0';
-	'psmake.mod.testing' = '1.1.0.0';
+	'psmake.mod.testing' = '1.3.1.1';
 }


### PR DESCRIPTION
Fixed the Makefile.ps1 to:
* build new csproj formats
* test with coverage the unit tests (changed opencover to dotcover)
* generate proper package with netcoreapp2.0 binaries and helper bat file to run it